### PR TITLE
feat: Add user verification step before graph generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from genai_funs import generate_graph, re_write_recipe, improve_graph, draft_to_
 from aux_funs import create_python_file_from_string
 from aux_vars import GENERATE_GRAPH_SYS_PROMPT, IMPROVE_GRAPH_SYS_PROMPT, RE_WRITE_SYS_PROMPT, DRAFT_TO_RECIPE_SYS_PROMPT
 from pathlib import Path
+import sys # Import sys for sys.exit
 
 PROJECT_ID = os.getenv("PROJECT_ID")
 DEFAULT_VERTEX_LOCATION = "us-central1"
@@ -18,30 +19,163 @@ INITIAL_GRAPHVIZ_SOURCE = "initial_recipe_flow"
 FINAL_GRAPHVIZ_SOURCE = "recipe_flow"
 
 
-if __name__ == "__main__":
+def process_recipe(recipe_draft_path_str: str):
+    """
+    Processes a recipe draft: converts, standardizes, verifies with user,
+    generates initial and improved graphs, and cleans up intermediate files.
 
+    Args:
+        recipe_draft_path_str: Path to the recipe draft file.
+
+    Raises:
+        FileNotFoundError: If the recipe draft file is not found.
+        ValueError: If input or configuration is invalid.
+        RuntimeError: If AI processing fails.
+        Exception: For other unexpected errors.
+    """
+    standardised_recipe = None
+    recipe_draft_text = None
+    input_source_description = f"draft file '{recipe_draft_path_str}'"
+
+    print(f"Processing recipe from {input_source_description}...")
+    draft_path = Path(recipe_draft_path_str)
+
+    if not draft_path.is_file():
+        raise FileNotFoundError(f"Recipe draft file not found: {draft_path}")
+
+    with open(draft_path, "r", encoding="utf-8") as f:
+        recipe_draft_text = f.read()
+
+    print("Converting draft to structured recipe...")
+    recipe = draft_to_recipe(
+        recipe_draft=recipe_draft_text,
+        system_instruction=DRAFT_TO_RECIPE_SYS_PROMPT,
+        project_id=PROJECT_ID,
+        location=DEFAULT_VERTEX_LOCATION,
+        model_name=DEFAULT_MODEL_NAME
+    )
+
+    print("Standardizing structured recipe...")
+    standardised_recipe = re_write_recipe(
+        recipe_input=recipe,
+        input_type="txt",
+        system_instruction=RE_WRITE_SYS_PROMPT,
+        project_id=PROJECT_ID,
+        location=DEFAULT_VERTEX_LOCATION,
+        model_name=DEFAULT_MODEL_NAME
+    )
+
+    # --- User Verification ---
+    print("\n--- Standardized Recipe for Review ---")
+    print(standardised_recipe)
+    print("--------------------------------------\n")
+    user_confirmation = input("Are you happy with the standardized recipe? (yes/no): ").lower()
+    if user_confirmation != 'yes':
+        print("Process aborted by user.")
+        sys.exit(0)
+    # --- End User Verification ---
+
+    if standardised_recipe:
+        try:
+            output_recipe_path = Path(STANDARDISED_RECIPE_FILENAME)
+            with open(output_recipe_path, "w", encoding="utf-8") as f:
+                f.write(standardised_recipe)
+            print(f"Successfully wrote standardized recipe to '{STANDARDISED_RECIPE_FILENAME}'")
+        except IOError as e:
+            print(f"Warning: Could not write standardized recipe to file '{STANDARDISED_RECIPE_FILENAME}': {e}")
+
+    else:
+        print("\nError: Standardized recipe could not be generated.\n")
+        sys.exit(1)
+
+
+    print("Generating initial graph code...")
+    first_pass_graph_code = generate_graph(
+        standardised_recipe=standardised_recipe,
+        system_instruction=GENERATE_GRAPH_SYS_PROMPT,
+        project_id=PROJECT_ID,
+        location=DEFAULT_VERTEX_LOCATION,
+        model_name=DEFAULT_MODEL_NAME
+    )
+    print("Initial graph code generated.")
+
+    temp_script_name = DEFAULT_GRAPH_SCRIPT_FILENAME
+    create_python_file_from_string(first_pass_graph_code, filename=temp_script_name)
+    print(f"Executing initial graph script: {temp_script_name}")
+    os.system(f"python {temp_script_name}")
+    print("Initial graph script execution finished (check 'initial_recipe_flow.pdf').")
+
+    try:
+        initial_dot_file_path = Path(INITIAL_GRAPHVIZ_SOURCE)
+        if initial_dot_file_path.exists():
+            initial_dot_file_path.unlink()
+            print(f"Cleaned up intermediate file: {initial_dot_file_path}")
+    except OSError as e:
+        print(f"Warning: Could not remove intermediate file {initial_dot_file_path}: {e}")
+
+    try:
+        os.remove(temp_script_name)
+        print(f"Removed temporary script: {temp_script_name}")
+    except OSError as e:
+        print(f"Warning: Could not remove temporary script {temp_script_name}: {e}")
+
+
+    print("Improving graph code...")
+    improved_graph_code = improve_graph(
+            standardised_recipe=standardised_recipe,
+            graph_code=first_pass_graph_code,
+            system_instruction=IMPROVE_GRAPH_SYS_PROMPT,
+            project_id=PROJECT_ID,
+            location=DEFAULT_VERTEX_LOCATION,
+            model_name=DEFAULT_MODEL_NAME
+    )
+    print("Graph code improvement finished.")
+
+    create_python_file_from_string(improved_graph_code, filename=temp_script_name)
+    print(f"Executing final graph script: {temp_script_name}")
+    os.system(f"python {temp_script_name}")
+    print("Final graph script execution finished (check 'recipe_flow.pdf').")
+
+    try:
+        final_dot_file_path = Path(FINAL_GRAPHVIZ_SOURCE)
+        if final_dot_file_path.exists():
+            final_dot_file_path.unlink()
+            print(f"Cleaned up intermediate file: {final_dot_file_path}")
+    except OSError as e:
+        print(f"Warning: Could not remove intermediate file {final_dot_file_path}: {e}")
+
+    try:
+        temp_script_path = Path(temp_script_name)
+        if temp_script_path.exists():
+            temp_script_path.unlink()
+            print(f"Cleaned up final temporary script: {temp_script_path}")
+    except OSError as e:
+        print(f"Warning: Could not clean up final temporary script {temp_script_path}: {e}")
+
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate a Graphviz diagram from a recipe draft.")
     parser.add_argument("--recipe_draft", required=True, help="Path to a file containing a recipe draft.")
     args = parser.parse_args()
 
-    standardised_recipe = None
-    recipe_draft_text = None
-    input_source_description = ""
-
     try:
-        if args.recipe_draft:
-            input_source_description = f"draft file '{args.recipe_draft}'"
-            print(f"Processing recipe from {input_source_description}...")
-            draft_path = Path(args.recipe_draft)
+        # Call the main processing function
+        process_recipe(args.recipe_draft)
 
-            if not draft_path.is_file():
-                 raise FileNotFoundError(f"Recipe draft file not found: {draft_path}")
+    except FileNotFoundError as e:
+        print(f"Error: Input file not found - {e}")
+        sys.exit(1)
+    except ValueError as e:
+        print(f"Error: Input or configuration error - {e}")
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"Error: AI processing failed - {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        sys.exit(1)
 
-            with open(args.recipe_draft, "r", encoding="utf-8") as f:
-                recipe_draft_text = f.read()
-
-            print("Converting draft to structured recipe...")
-            recipe = draft_to_recipe(
+    print("\nProcess completed.")
                 recipe_draft=recipe_draft_text,
                 system_instruction=DRAFT_TO_RECIPE_SYS_PROMPT,
                 project_id=PROJECT_ID,
@@ -58,6 +192,16 @@ if __name__ == "__main__":
                 location=DEFAULT_VERTEX_LOCATION,
                 model_name=DEFAULT_MODEL_NAME
             )
+
+            # --- User Verification ---
+            print("\n--- Standardized Recipe for Review ---")
+            print(standardised_recipe)
+            print("--------------------------------------\n")
+            user_confirmation = input("Are you happy with the standardized recipe? (yes/no): ").lower()
+            if user_confirmation != 'yes':
+                print("Process aborted by user.")
+                exit(0)
+            # --- End User Verification ---
 
             if standardised_recipe:
                 try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+from pathlib import Path
+
+# Add project root to sys.path to allow importing main
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import the function to test AFTER potentially modifying sys.path
+try:
+    from main import process_recipe
+except ImportError as e:
+    # Provide a more informative error if main cannot be imported
+    raise ImportError(f"Could not import 'process_recipe' from 'main'. Original error: {e}\nMake sure main.py is in the project root: {project_root}") from e
+
+# Mock constants and functions from external modules used in process_recipe
+# We mock them globally here so they don't interfere with the specific tests unless needed
+@patch('main.PROJECT_ID', 'test-project')
+@patch('main.DEFAULT_VERTEX_LOCATION', 'test-location')
+@patch('main.DEFAULT_MODEL_NAME', 'test-model')
+@patch('main.STANDARDISED_RECIPE_FILENAME', 'test_standardised_recipe.txt')
+@patch('main.DEFAULT_GRAPH_SCRIPT_FILENAME', 'test_create_graph.py')
+@patch('main.INITIAL_GRAPHVIZ_SOURCE', 'test_initial_recipe_flow')
+@patch('main.FINAL_GRAPHVIZ_SOURCE', 'test_recipe_flow')
+@patch('main.draft_to_recipe', return_value="Mocked structured recipe")
+@patch('main.re_write_recipe', return_value="Mocked standardised recipe")
+@patch('main.generate_graph', return_value="mock graph code")
+@patch('main.create_python_file_from_string', return_value=None)
+@patch('main.os.system', return_value=0) # Mock os.system to avoid actual execution
+@patch('main.improve_graph', return_value="mock improved graph code")
+@patch('main.Path.unlink', return_value=None) # Mock unlink to avoid file errors
+@patch('main.os.remove', return_value=None) # Mock os.remove
+@patch('main.Path.is_file', return_value=True) # Assume file exists
+@patch('builtins.open', new_callable=unittest.mock.mock_open, read_data="mock recipe draft")
+class TestMainVerification(unittest.TestCase):
+
+    # These mocks are passed by the class decorator to each test method
+    def test_user_approves_recipe(self, mock_open, mock_is_file, mock_os_remove, mock_unlink, mock_improve_graph, mock_os_system, mock_create_py_file, mock_generate_graph, mock_rewrite, mock_draft_to_recipe, *args):
+        """Tests that processing continues when user inputs 'yes'."""
+        with patch('builtins.input', return_value='yes'), \
+             patch('sys.exit') as mock_exit: # Mock sys.exit specifically for this test
+
+            # Create a dummy recipe draft file path (doesn't need to exist due to mocks)
+            dummy_draft_path = "dummy_recipe.txt"
+
+            # Call the function under test
+            process_recipe(dummy_draft_path)
+
+            # Assertions
+            mock_exit.assert_not_called() # Exit should not be called
+            mock_generate_graph.assert_called_once() # Graph generation should be called
+            mock_improve_graph.assert_called_once() # Graph improvement should be called
+
+    # These mocks are passed by the class decorator to each test method
+    def test_user_rejects_recipe(self, mock_open, mock_is_file, mock_os_remove, mock_unlink, mock_improve_graph, mock_os_system, mock_create_py_file, mock_generate_graph, mock_rewrite, mock_draft_to_recipe, *args):
+        """Tests that processing stops when user inputs anything other than 'yes'."""
+        with patch('builtins.input', return_value='no'), \
+             patch('sys.exit') as mock_exit: # Mock sys.exit specifically for this test
+
+            # Create a dummy recipe draft file path
+            dummy_draft_path = "dummy_recipe.txt"
+
+            # Call the function under test
+            process_recipe(dummy_draft_path)
+
+            # Assertions
+            mock_exit.assert_called_once_with(0) # sys.exit(0) should be called
+            mock_generate_graph.assert_not_called() # Graph generation should NOT be called
+            mock_improve_graph.assert_not_called() # Graph improvement should NOT be called
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Introduces a user confirmation step after the recipe standardization process in `main.py`.

- The standardized recipe is printed to the console.
- The user is prompted to approve ('yes') or reject ('no') the recipe.
- If approved, the script proceeds to graph generation.
- If rejected, the script prints a message and exits gracefully.

Refactored `main.py` to extract core logic into `process_recipe` function for better testability.

Added unit tests in `tests/test_main.py` to cover both approval and rejection scenarios, using mocking for user input and function calls.