### PR TITLE
feat: Introduce separate default temperatures for agents

### DIFF
--- a/r2g_app/genai_funs.py
+++ b/r2g_app/genai_funs.py
@@ -49,7 +49,7 @@ def _get_genai_client(
 def _build_generate_content_config(
     system_instruction_text: Optional[str] = None,
     tools: Optional[List[types.Tool]] = None,
-    temperature: float = DEFAULT_TEMPERATURE,
+    temperature: Optional[float] = None,
     top_p: float = DEFAULT_TOP_P,
     max_output_tokens: int = DEFAULT_MAX_TOKENS,
 ) -> types.GenerateContentConfig:
@@ -74,7 +74,7 @@ def _build_generate_content_config(
     ]
 
     config_kwargs: Dict[str, Any] = {
-        "temperature": temperature,
+        "temperature": temperature if temperature is not None else DEFAULT_TEMPERATURE,
         "top_p": top_p,
         "max_output_tokens": max_output_tokens,
         "safety_settings": safety_settings,
@@ -131,7 +131,8 @@ def draft_to_recipe(
     system_instruction: str,
     project_id: Optional[str] = DEFAULT_VERTEX_PROJECT_ID,
     location: str = DEFAULT_VERTEX_LOCATION,
-    model_name: str = DEFAULT_MODEL_NAME
+    model_name: str = DEFAULT_MODEL_NAME,
+    temperature: Optional[float] = None
 ) -> str:
     """
     Transforms a recipe draft into a standardized recipe using a GenAI model.
@@ -158,7 +159,8 @@ def draft_to_recipe(
     tools = [types.Tool(google_search=types.GoogleSearch())]
     config = _build_generate_content_config(
         system_instruction_text=system_instruction,
-        tools=tools
+        tools=tools,
+        temperature=temperature
     )
 
     response_text = _call_generate_content(client, model_name, contents, config)
@@ -172,7 +174,8 @@ def re_write_recipe(
     system_instruction: str,
     project_id: Optional[str] = DEFAULT_VERTEX_PROJECT_ID,
     location: str = DEFAULT_VERTEX_LOCATION,
-    model_name: str = DEFAULT_MODEL_NAME
+    model_name: str = DEFAULT_MODEL_NAME,
+    temperature: Optional[float] = None
 ) -> str:
     """
     Rewrites a recipe from text or a YouTube video URI into a standardized format.
@@ -217,7 +220,10 @@ def re_write_recipe(
         raise ValueError(f"Invalid input_type: '{input_type}'. Must be 'txt' or 'youtube'.")
 
     contents = [types.Content(role="user", parts=parts)]
-    config = _build_generate_content_config(system_instruction_text=system_instruction)
+    config = _build_generate_content_config(
+        system_instruction_text=system_instruction,
+        temperature=temperature
+    )
 
     response_text = _call_generate_content(client, model_name, contents, config)
 
@@ -229,7 +235,8 @@ def generate_graph(
     system_instruction: str,
     project_id: Optional[str] = DEFAULT_VERTEX_PROJECT_ID,
     location: str = DEFAULT_VERTEX_LOCATION,
-    model_name: str = DEFAULT_MODEL_NAME
+    model_name: str = DEFAULT_MODEL_NAME,
+    temperature: Optional[float] = None
 ) -> str:
     """
     Generates initial Graphviz Python code from a standardized recipe.
@@ -256,7 +263,8 @@ def generate_graph(
     tools = [types.Tool(google_search=types.GoogleSearch())]
     config = _build_generate_content_config(
         system_instruction_text=system_instruction,
-        tools=tools
+        tools=tools,
+        temperature=temperature
     )
 
     response_text = _call_generate_content(client, model_name, contents, config)
@@ -270,7 +278,8 @@ def improve_graph(
     system_instruction: str,
     project_id: Optional[str] = DEFAULT_VERTEX_PROJECT_ID,
     location: str = DEFAULT_VERTEX_LOCATION,
-    model_name: str = DEFAULT_MODEL_NAME
+    model_name: str = DEFAULT_MODEL_NAME,
+    temperature: Optional[float] = None
 ) -> str:
     """
     Improves existing Graphviz Python code based on the recipe and instructions.
@@ -304,7 +313,8 @@ def improve_graph(
     tools = [types.Tool(google_search=types.GoogleSearch())]
     config = _build_generate_content_config(
         system_instruction_text=system_instruction,
-        tools=tools
+        tools=tools,
+        temperature=temperature
     )
 
     response_text = _call_generate_content(client, model_name, contents, config)

--- a/r2g_app/main.py
+++ b/r2g_app/main.py
@@ -60,7 +60,8 @@ def process_text(recipe_draft_text: str, project_id: str) -> str:
             system_instruction=DRAFT_TO_RECIPE_SYS_PROMPT,
             project_id=project_id,  # Use function argument
             location=DEFAULT_VERTEX_LOCATION,
-            model_name=DEFAULT_MODEL_NAME
+            model_name=DEFAULT_MODEL_NAME,
+            temperature=0.8  # Add temperature
         )
 
         print("Standardizing structured recipe...") # Keep print for server logs
@@ -70,7 +71,8 @@ def process_text(recipe_draft_text: str, project_id: str) -> str:
             system_instruction=RE_WRITE_SYS_PROMPT,
             project_id=project_id,  # Use function argument
             location=DEFAULT_VERTEX_LOCATION,
-            model_name=DEFAULT_MODEL_NAME
+            model_name=DEFAULT_MODEL_NAME,
+            temperature=0.8  # Add temperature
         )
 
     except Exception as e:
@@ -168,7 +170,8 @@ def text_to_graph(standardised_recipe: str, recipe_name: str, gcs_bucket_name: s
             system_instruction=GENERATE_GRAPH_SYS_PROMPT,
             project_id=project_id,  # Use function argument
             location=DEFAULT_VERTEX_LOCATION,
-            model_name=DEFAULT_MODEL_NAME
+            model_name=DEFAULT_MODEL_NAME,
+            temperature=0.2  # Add temperature
         )
         print("Initial graph code generated.") # Keep print
 
@@ -183,7 +186,8 @@ def text_to_graph(standardised_recipe: str, recipe_name: str, gcs_bucket_name: s
                 system_instruction=IMPROVE_GRAPH_SYS_PROMPT,
                 project_id=project_id,  # Use function argument
                 location=DEFAULT_VERTEX_LOCATION,
-                model_name=DEFAULT_MODEL_NAME
+                model_name=DEFAULT_MODEL_NAME,
+                temperature=0.2  # Add temperature
         )
         print("Graph code improvement finished.") # Keep print
 
@@ -336,7 +340,8 @@ Based *only* on the User Feedback provided above, please revise the Current Stan
             system_instruction=REVISE_RECIPE_SYS_PROMPT, # Use the new prompt
             project_id=project_id,
             location=DEFAULT_VERTEX_LOCATION,
-            model_name=DEFAULT_MODEL_NAME
+            model_name=DEFAULT_MODEL_NAME,
+            temperature=0.8  # Add temperature
         )
         if not revised_text:
             raise RuntimeError("AI revision returned an empty result.")

--- a/tests/test_genai_funs.py
+++ b/tests/test_genai_funs.py
@@ -18,28 +18,28 @@ class TestGenAIFuns(unittest.TestCase):
     
     def test_re_write_recipe(self):
         # Call the function with a dummy recipe
-        recipe = "This is a test recipe"
+        recipe_input = "This is a test recipe"
         # Call the function
-        result = re_write_recipe(project_id=PROJECT_ID, recipe=recipe, input_type="txt", si_text="test_prompt")
+        result = re_write_recipe(project_id=PROJECT_ID, recipe_input=recipe_input, input_type="txt", system_instruction="test_prompt")
         # Check if the result is a non empty string
         self.assertIsInstance(result, str)
         self.assertNotEqual(result, "")
         
     def test_generate_graph(self):
         # Call the function with a dummy recipe
-        recipe = "This is a test recipe"
+        recipe_input = "This is a test recipe" # Corrected variable name
         # Call the function
-        result = generate_graph(project_id=PROJECT_ID, recipe=recipe, si_text="test_prompt")
+        result = generate_graph(project_id=PROJECT_ID, recipe_input=recipe_input, system_instruction="test_prompt") # Corrected argument name
         # Check if the result is a non empty string
         self.assertIsInstance(result, str)
         self.assertNotEqual(result, "")
 
     def test_improve_graph(self):
         # Call the function with a dummy recipe
-        recipe = "This is a test recipe"
+        recipe_input = "This is a test recipe" # Corrected variable name
         graph_code = "graph code"
         # Call the function
-        result = improve_graph(project_id=PROJECT_ID, recipe=recipe, graph_code=graph_code, si_text="test_prompt")
+        result = improve_graph(project_id=PROJECT_ID, recipe_input=recipe_input, graph_code=graph_code, system_instruction="test_prompt") # Corrected argument name
         # Check if the result is a non empty string
         self.assertIsInstance(result, str)
         self.assertNotEqual(result, "")


### PR DESCRIPTION
Allows configuring different default temperatures for text processing and graph generation agents.

- Modified `genai_funs.py` to allow temperature override in agent functions and config builder.
- Modified `main.py` to pass specific temperatures:
    - Text processing (`draft_to_recipe`, `re_write_recipe`, `revise_recipe`): 0.8
    - Graph generation (`generate_graph`, `improve_graph`): 0.2
- Updated basic tests in `test_genai_funs.py` to match new signatures.