### PR TITLE
Refactor: Use separate Gemini models for text processing and graph ge…

### DIFF
--- a/r2g_app/genai_funs.py
+++ b/r2g_app/genai_funs.py
@@ -8,7 +8,9 @@ from google.genai import types
 PROJECT_ID = os.getenv("PROJECT_ID")
 DEFAULT_VERTEX_LOCATION = "us-central1"
 #DEFAULT_MODEL_NAME = "gemini-2.5-pro-exp-03-25" 
-DEFAULT_MODEL_NAME = "gemini-2.5-pro-preview-05-06"
+#DEFAULT_MODEL_NAME = "gemini-2.5-pro-preview-05-06" # To be removed
+PROCESS_TEXT_MODEL_NAME = "gemini-2.5-pro-preview-05-06"
+TEXT_TO_GRAPH_MODEL_NAME = "gemini-2.5-pro-preview-05-06"
 DEFAULT_TOP_P = 1.0
 DEFAULT_MAX_TOKENS = 33333
 
@@ -146,7 +148,7 @@ def draft_to_recipe(
     system_instruction: str,
     project_id: Optional[str] = PROJECT_ID,
     location: str = DEFAULT_VERTEX_LOCATION,
-    model_name: str = DEFAULT_MODEL_NAME,
+    model_name: str = PROCESS_TEXT_MODEL_NAME,
     temperature: float = RECIPE_DRAFT_TEMP, # Use specific constant
     max_output_tokens: int = DEFAULT_MAX_TOKENS
 ) -> str:
@@ -191,7 +193,7 @@ def re_write_recipe(
     system_instruction: str,
     project_id: Optional[str] = PROJECT_ID,
     location: str = DEFAULT_VERTEX_LOCATION,
-    model_name: str = DEFAULT_MODEL_NAME,
+    model_name: str = PROCESS_TEXT_MODEL_NAME,
     temperature: float = RECIPE_REWRITE_TEMP, # Use specific constant
     max_output_tokens: int = DEFAULT_MAX_TOKENS
 ) -> str:
@@ -254,7 +256,7 @@ def generate_graph(
     system_instruction: str,
     project_id: Optional[str] = PROJECT_ID,
     location: str = DEFAULT_VERTEX_LOCATION,
-    model_name: str = DEFAULT_MODEL_NAME,
+    model_name: str = TEXT_TO_GRAPH_MODEL_NAME,
     temperature: float = GRAPH_GEN_TEMP, # Use specific constant
     max_output_tokens: int = DEFAULT_MAX_TOKENS
 ) -> str:
@@ -299,7 +301,7 @@ def improve_graph(
     system_instruction: str,
     project_id: Optional[str] = PROJECT_ID,
     location: str = DEFAULT_VERTEX_LOCATION,
-    model_name: str = DEFAULT_MODEL_NAME,
+    model_name: str = TEXT_TO_GRAPH_MODEL_NAME,
     temperature: float = GRAPH_IMPROVE_TEMP, # Use specific constant
     max_output_tokens: int = DEFAULT_MAX_TOKENS
 ) -> str:

--- a/r2g_app/main.py
+++ b/r2g_app/main.py
@@ -3,7 +3,8 @@ import os
 from .genai_funs import generate_graph, re_write_recipe, improve_graph, draft_to_recipe
 # Import constants from genai_funs
 from .genai_funs import (
-    PROJECT_ID, DEFAULT_VERTEX_LOCATION, DEFAULT_MODEL_NAME,
+    PROJECT_ID, DEFAULT_VERTEX_LOCATION,
+    PROCESS_TEXT_MODEL_NAME, TEXT_TO_GRAPH_MODEL_NAME,
     RECIPE_DRAFT_TEMP, RECIPE_REWRITE_TEMP, RECIPE_REVISE_TEMP,
     GRAPH_GEN_TEMP, GRAPH_IMPROVE_TEMP
 )
@@ -61,7 +62,7 @@ def process_text(recipe_draft_text: str, project_id: str) -> str:
             system_instruction=DRAFT_TO_RECIPE_SYS_PROMPT,
             project_id=project_id,  # Pass explicitly
             location=DEFAULT_VERTEX_LOCATION, # Use imported constant
-            model_name=DEFAULT_MODEL_NAME, # Use imported constant
+            model_name=PROCESS_TEXT_MODEL_NAME, # Use imported constant
             temperature=RECIPE_DRAFT_TEMP # Use imported constant
         )
 
@@ -73,7 +74,7 @@ def process_text(recipe_draft_text: str, project_id: str) -> str:
             system_instruction=RE_WRITE_SYS_PROMPT,
             project_id=project_id,  # Pass explicitly
             location=DEFAULT_VERTEX_LOCATION, # Use imported constant
-            model_name=DEFAULT_MODEL_NAME, # Use imported constant
+            model_name=PROCESS_TEXT_MODEL_NAME, # Use imported constant
             temperature=RECIPE_REWRITE_TEMP # Use imported constant
         )
 
@@ -173,7 +174,7 @@ def text_to_graph(standardised_recipe: str, recipe_name: str, gcs_bucket_name: s
             system_instruction=GENERATE_GRAPH_SYS_PROMPT,
             project_id=project_id,  # Pass explicitly
             location=DEFAULT_VERTEX_LOCATION, # Use imported constant
-            model_name=DEFAULT_MODEL_NAME, # Use imported constant
+            model_name=TEXT_TO_GRAPH_MODEL_NAME, # Use imported constant
             temperature=GRAPH_GEN_TEMP # Use imported constant
         )
         print("Initial graph code generated.") # Keep print
@@ -190,7 +191,7 @@ def text_to_graph(standardised_recipe: str, recipe_name: str, gcs_bucket_name: s
                 system_instruction=IMPROVE_GRAPH_SYS_PROMPT,
                 project_id=project_id,  # Pass explicitly
                 location=DEFAULT_VERTEX_LOCATION, # Use imported constant
-                model_name=DEFAULT_MODEL_NAME, # Use imported constant
+                model_name=TEXT_TO_GRAPH_MODEL_NAME, # Use imported constant
                 temperature=GRAPH_IMPROVE_TEMP # Use imported constant
         )
         print("Graph code improvement finished.") # Keep print
@@ -344,7 +345,7 @@ Based *only* on the User Feedback provided above, please revise the Current Stan
             system_instruction=REVISE_RECIPE_SYS_PROMPT, # Use the new prompt
             project_id=project_id, # Pass explicitly
             location=DEFAULT_VERTEX_LOCATION, # Use imported constant
-            model_name=DEFAULT_MODEL_NAME, # Use imported constant
+            model_name=PROCESS_TEXT_MODEL_NAME, # Use imported constant
             temperature=RECIPE_REVISE_TEMP # Use imported constant
         )
         if not revised_text:


### PR DESCRIPTION
…neration

I introduced two new model name constants:
- `PROCESS_TEXT_MODEL_NAME` for `draft_to_recipe` and `re_write_recipe` functions.
- `TEXT_TO_GRAPH_MODEL_NAME` for `generate_graph` and `improve_graph` functions.

This allows for different Gemini models to be used in the "process text" and "text to graph" stages of the application.

The old `DEFAULT_MODEL_NAME` constant has been removed. Function signatures and calls in `genai_funs.py` and `main.py` have been updated to use the new model name variables. The `revise_recipe` function now uses `PROCESS_TEXT_MODEL_NAME`.