### PR TITLE
Add string parser for HTML, CSS, and JS code blocks

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,36 @@
+import re
+
+def parse_code_string(code_string: str):
+  """
+  Parses a string of code to extract HTML, CSS, and JavaScript content.
+  """
+  html_regex = re.compile(r'```html filename="index\.html"(.*?)```', re.DOTALL)
+  css_regex = re.compile(r'```css filename="style\.css"(.*?)```', re.DOTALL)
+  js_regex = re.compile(r'```javascript filename="script\.js"(.*?)```', re.DOTALL)
+
+  html_match = html_regex.search(code_string)
+  css_match = css_regex.search(code_string)
+  js_match = js_regex.search(code_string)
+
+  html_content = html_match.group(1).strip() if html_match else ""
+  css_content = css_match.group(1).strip() if css_match else ""
+  js_content = js_match.group(1).strip() if js_match else ""
+
+  return {
+    "index.html": html_content,
+    "style.css": css_content,
+    "script.js": js_content,
+  }
+
+import os
+
+def save_files(parsed_content: dict, output_directory: str = "."):
+  """
+  Saves the parsed code content into files.
+  """
+  os.makedirs(output_directory, exist_ok=True)
+  for filename, content in parsed_content.items():
+    filepath = os.path.join(output_directory, filename)
+    with open(filepath, "w", encoding="utf-8") as f:
+      f.write(content)
+    print(f"Saving {filename} to {filepath}")

--- a/test_parser.py
+++ b/test_parser.py
@@ -1,0 +1,90 @@
+import unittest
+from parser import parse_code_string
+
+class TestCodeParser(unittest.TestCase):
+
+    def test_parse_valid_string(self):
+        sample_input = """
+```html filename="index.html"
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Webpage</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Hello, World!</h1>
+    <p>This is a sample HTML page.</p>
+    <script src="script.js"></script>
+</body>
+</html>
+```
+
+```css filename="style.css"
+body {
+    font-family: sans-serif;
+    margin: 0;
+    background-color: #f0f0f0;
+}
+
+h1 {
+    color: #333;
+    text-align: center;
+    padding: 1em 0;
+}
+```
+
+```javascript filename="script.js"
+document.addEventListener('DOMContentLoaded', () => {
+    const heading = document.querySelector('h1');
+    heading.addEventListener('click', () => {
+        alert('Heading clicked!');
+    });
+});
+```
+"""
+        parsed_content = parse_code_string(sample_input)
+        self.assertIsInstance(parsed_content, dict)
+        self.assertIn("index.html", parsed_content)
+        self.assertTrue(parsed_content["index.html"].startswith("<!DOCTYPE html>"))
+        self.assertTrue(parsed_content["index.html"].endswith("</html>"))
+        self.assertIn("style.css", parsed_content)
+        self.assertTrue(parsed_content["style.css"].startswith("body {"))
+        self.assertTrue(parsed_content["style.css"].endswith("}"))
+        self.assertIn("script.js", parsed_content)
+        self.assertTrue(parsed_content["script.js"].startswith("document.addEventListener"))
+        self.assertTrue(parsed_content["script.js"].endswith("});"))
+
+    def test_parse_empty_string(self):
+        parsed_content = parse_code_string("")
+        self.assertEqual(parsed_content["index.html"], "")
+        self.assertEqual(parsed_content["style.css"], "")
+        self.assertEqual(parsed_content["script.js"], "")
+
+    def test_parse_missing_css_block(self):
+        input_missing_css = """
+```html filename="index.html"
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test</title>
+</head>
+<body>
+    <p>No CSS here.</p>
+</body>
+</html>
+```
+
+```javascript filename="script.js"
+console.log("No CSS block test");
+```
+"""
+        parsed_content = parse_code_string(input_missing_css)
+        self.assertTrue(parsed_content["index.html"].startswith("<!DOCTYPE html>"))
+        self.assertTrue(parsed_content["script.js"].startswith("console.log"))
+        self.assertEqual(parsed_content["style.css"], "")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a Python script capable of parsing a single string containing tagged code blocks for HTML, CSS, and JavaScript, and extracting them into separate components.

Key features:
- `parser.py`:
    - `parse_code_string(code_string)`: Uses regular expressions to identify and extract content for `index.html`, `style.css`, and `script.js` based on filename attributes in the markdown-like code fences.
    - `save_files(parsed_content, output_directory)`: A helper function to save the extracted code blocks into their respective files in a specified directory.
- `test_parser.py`:
    - Includes unit tests for `parse_code_string` covering: - Parsing a valid string with all three code types. - Parsing an empty string. - Parsing a string with a missing code block (e.g., no CSS).

The parser correctly handles multiline content within the code blocks and defaults to empty strings for missing blocks.