### PR TITLE
Set Streamlit page layout to 'wide'

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -7,6 +7,8 @@ from r2g_app.main import process_text, text_to_graph
 from r2g_app.main import revise_recipe
 import re # Import re for GCS link validation/parsing (optional but good practice)
 
+st.set_page_config(layout="wide") # Set page layout to wide
+
 # Initialize session state variables
 if "standardized_recipe_text" not in st.session_state:
     st.session_state.standardized_recipe_text = ""


### PR DESCRIPTION
This change configures the Streamlit application to use the 'wide' layout, increasing the overall width of the webpage content area. This addresses your request to make the page wider.