### PR TITLE
feat: Add download buttons for frontend files

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -224,6 +224,29 @@ if st.session_state.recipe_approved and st.session_state.graph_results:
     js_content = results.get("js_content")
     # print(f"DEBUG: js_content: {js_content}")
 
+    # --- Add Download Buttons ---
+    if html_content:
+        st.download_button(
+            label="Download HTML",
+            data=html_content,
+            file_name="index.html",
+            mime="text/html"
+        )
+    if css_content:
+        st.download_button(
+            label="Download CSS",
+            data=css_content,
+            file_name="style.css",
+            mime="text/css"
+        )
+    if js_content:
+        st.download_button(
+            label="Download JS",
+            data=js_content,
+            file_name="script.js",
+            mime="application/javascript"
+        )
+
     # Initialize graph_nodes_html with a generic fallback message
     # graph_nodes_html = "<p>An unexpected issue occurred while preparing graph data.</p>"
 


### PR DESCRIPTION
This commit introduces functionality to download the HTML, CSS, and JavaScript files directly from the Streamlit application interface.

Previously, you could only see GCS links for these files. Now, `st.download_button` has been implemented for `index.html`, `style.css`, and `script.js` when the graph results are displayed. This provides a more direct way for you to access these generated frontend assets.

The following changes were made:
- Modified `st_app.py` to include `st.download_button` for each file type (HTML, CSS, JS).
- Ensured buttons only appear if the respective content is available.
- Set appropriate file names (`index.html`, `style.css`, `script.js`) and MIME types for the downloads.