### PR TITLE
feat: Add graph preview to Streamlit app

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -224,6 +224,32 @@ if st.session_state.recipe_approved and st.session_state.graph_results:
     js_content = results.get("js_content")
     # print(f"DEBUG: js_content: {js_content}")
 
+    # --- Display Graph Preview ---
+    if html_content and css_content and js_content:
+        st.subheader("Graph Preview:")
+        constructed_html = f"""
+        <html>
+        <head>
+        <style>
+        {css_content}
+        </style>
+        </head>
+        <body>
+        {html_content}
+        <script>
+        {js_content}
+        </script>
+        </body>
+        </html>
+        """
+        st.components.v1.html(constructed_html, height=600)
+    elif html_content:
+        # Fallback if CSS or JS is missing but HTML is present
+        st.subheader("Graph Preview (HTML only):")
+        st.components.v1.html(html_content, height=600)
+    else:
+        st.warning("HTML content for graph preview is not available.")
+
     # --- Add Download Buttons ---
     if html_content:
         st.download_button(


### PR DESCRIPTION
This change introduces a new section in the Streamlit application to display a preview of the generated HTML/CSS/JS graph.

The preview is rendered directly within the app using `st.components.v1.html`. The CSS and JavaScript content are embedded into the HTML for self-contained display. This allows you to see the graph output without needing to download the files first.

The following modifications were made:
- In `st_app.py`, within the final results display section:
  - Retrieved `html_content`, `css_content`, and `js_content` from session state.
  - Constructed an HTML string that embeds CSS in `<style>` tags and JS in `<script>` tags.
  - Used `st.components.v1.html()` to render this constructed HTML, with a default height of 600px.
  - Added fallbacks for cases where CSS/JS might be missing or if HTML content itself is unavailable.